### PR TITLE
Ref handling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ pnpm sg-schema-sync -i <path_or_url_to_openapi_spec> -o ./src/api/generated
 *   `--default-requester-token-export-name <name>`: (Optional) Specifies the export name of your `getToken` function. Defaults to `getToken`. Overrides `defaultRequesterConfig.getTokenExportName` in the config file.
 *   `--generated-client-module-basename <name>`: (Optional) Basename for the auto-generated per-tag client orchestrator module (e.g., `client` would result in `users/client.ts`). Defaults to `client`. Overrides `generatedClientModuleBasename` in the config file.
 *   `--strip-path-prefix <prefix>`: (Optional) A string prefix to strip from the beginning of all paths obtained from the OpenAPI specification before they are used for generating runtime request paths and influencing generated names (like hook names or query keys if they are path-based). For example, if your OpenAPI paths are `/api/users` and you provide `--strip-path-prefix /api`, the generated path constants will be `/users`. Type names (e.g., `_Request`, `_Response` types) will still be based on the original, unstripped path to maintain naming consistency. Defaults to no prefix stripping. Overrides `stripPathPrefix` in the config file.
+*   `operationTypePrefix?: string`: (Default: none) Optional prefix prepended to every *operation-specific* type that the generator creates (e.g. `GetUsers_Request`, `PostPets_Response_201`).  Provide a short Pascal-case string; if omitted, the old names are preserved.
+*   `schemaTypePrefix?: string`: (Default: `SSGEN_`) Prefix prepended to every auxiliary type that originates from `$ref` schemas (interfaces like `UserRoleInfo`, enums, etc.).  This prevents clashes when multiple specs are compiled inside the same code-base.
 
 ## Configuration File (`sg-schema-sync.config.js`)
 
@@ -137,6 +139,8 @@ It should export a `config` object: `module.exports = { config: { /* ... */ } };
 *   `formatWithPrettier: boolean`: (Default: `true`) Whether to format the generated output files using Prettier.
 *   `prettierConfigPath: string | undefined`: (Default: `undefined`) Path to a custom Prettier configuration file.
 *   `stripPathPrefix: string | undefined`: (Default: `undefined`) Optional string prefix to strip from paths.
+*   `operationTypePrefix?: string`: (Default: none) Optional prefix prepended to every *operation-specific* type that the generator creates (e.g. `GetUsers_Request`, `PostPets_Response_201`).  Provide a short Pascal-case string; if omitted, the old names are preserved.
+*   `schemaTypePrefix?: string`: (Default: `SSGEN_`) Prefix prepended to every auxiliary type that originates from `$ref` schemas (interfaces like `UserRoleInfo`, enums, etc.).  This prevents clashes when multiple specs are compiled inside the same code-base.
 *   *(Other fields like `defaultConfig` from the CLI are also part of `PackageConfig` but usually set via CLI or have sensible defaults).*
 
 **Example `sg-schema-sync.config.js`:**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -233,6 +233,8 @@ async function main() {
     scaffoldRequesterAdapter: mergedConfig.scaffoldRequesterAdapter ?? baseDefaultConfig.scaffoldRequesterAdapter!,
     stripPathPrefix: mergedConfig.stripPathPrefix,
     verbose: mergedConfig.verbose ?? baseDefaultConfig.verbose!,
+    operationTypePrefix: mergedConfig.operationTypePrefix ?? baseDefaultConfig.operationTypePrefix,
+    schemaTypePrefix: mergedConfig.schemaTypePrefix ?? baseDefaultConfig.schemaTypePrefix ?? "SSGEN_",
     defaultRequesterConfig: undefined, // Initialize, will be set if useDefaultRequester is true
   };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,6 +140,18 @@ export interface PackageConfig {
    * @default false
    */
   verbose?: boolean;
+
+  /**
+   * Optional prefix added to every OPERATION-specific type generated (Request/Response/Parameters).
+   * Provide a short PascalCase string. If omitted, no prefix is applied (back-compat behaviour).
+   */
+  operationTypePrefix?: string;
+
+  /**
+   * Prefix added to every auxiliary schema type generated from $ref references.
+   * Defaults to "SSGEN_" to avoid collisions in mono-repos.
+   */
+  schemaTypePrefix?: string;
 }
 
 /**
@@ -180,6 +192,9 @@ export interface ResolvedPackageConfig
   stripPathPrefix?: string;
   scaffoldRequesterAdapter: boolean; // Required in Resolved, default applied
   verbose: boolean; // Required in Resolved, default applied
+
+  operationTypePrefix?: string;
+  schemaTypePrefix: string; // Always resolved, default may apply
 }
 
 // Helper function to load and resolve configuration (conceptual)
@@ -218,6 +233,9 @@ export async function loadAndResolveConfig(
   const generateTypesNames = mergedConfig.generateTypesNames ?? defaultConfig.generateTypesNames;
   const generateHooksNames = mergedConfig.generateHooksNames ?? defaultConfig.generateHooksNames;
   const stripPathPrefix = mergedConfig.stripPathPrefix ?? defaultConfig.stripPathPrefix;
+
+  const operationTypePrefix = mergedConfig.operationTypePrefix ?? defaultConfig.operationTypePrefix;
+  const schemaTypePrefix = mergedConfig.schemaTypePrefix ?? defaultConfig.schemaTypePrefix ?? "SSGEN_";
 
   let resolvedDefaultRequesterConfig: Required<DefaultRequesterConfig> | undefined = undefined;
   if (useDefaultRequester) {
@@ -272,6 +290,8 @@ export async function loadAndResolveConfig(
     // Conditionally required
     ...(useDefaultRequester &&
       resolvedDefaultRequesterConfig && { defaultRequesterConfig: resolvedDefaultRequesterConfig }),
+    operationTypePrefix,
+    schemaTypePrefix,
   } as ResolvedPackageConfig;
 }
 
@@ -296,6 +316,9 @@ export const defaultConfig: Partial<PackageConfig> = {
   },
   // defaultRequesterConfig is not set here as it depends on useDefaultRequester being true
   // and getTokenModulePath would be required.
+
+  // New prefix defaults
+  schemaTypePrefix: "SSGEN_", // default applied to schema-derived types
 };
 
 // Base configuration combining parser and package settings

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -95,7 +95,7 @@ export async function generateFilesForTag(
       parametersTypeFailed,
       responseTypeFailed,
       primaryResponseTypeGenerated,
-    } = await _generateOperationTypes(opInfo, typeBaseNameForOperation, tagName, generatedTypeNames);
+    } = await _generateOperationTypes(opInfo, typeBaseNameForOperation, tagName, generatedTypeNames, spec);
     typesContent += operationTypesString;
 
     // Check if this operation necessitates importing from ./types

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -95,7 +95,14 @@ export async function generateFilesForTag(
       parametersTypeFailed,
       responseTypeFailed,
       primaryResponseTypeGenerated,
-    } = await _generateOperationTypes(opInfo, typeBaseNameForOperation, tagName, generatedTypeNames, spec);
+    } = await _generateOperationTypes(
+      opInfo,
+      typeBaseNameForOperation,
+      tagName,
+      generatedTypeNames,
+      spec,
+      packageConfig
+    );
     typesContent += operationTypesString;
 
     // Check if this operation necessitates importing from ./types

--- a/src/helpers/generator-parts.ts
+++ b/src/helpers/generator-parts.ts
@@ -602,7 +602,10 @@ function filterAndPrefixDeclarations(
         // Replace declaration line name in buffer
         const updatedLine = line.replace(currentName, prefixed);
         buffer.push(updatedLine);
-        // Replace all subsequent occurrences within buffer so far
+        // Update previously processed resultLines as well
+        for (let i = 0; i < resultLines.length; i++) {
+          resultLines[i] = resultLines[i].replace(new RegExp(`\\b${currentName}\\b`, "g"), prefixed);
+        }
         for (let i = 0; i < buffer.length - 1; i++) {
           buffer[i] = buffer[i].replace(new RegExp(`\\b${currentName}\\b`, "g"), prefixed);
         }


### PR DESCRIPTION
**Changelog:** 

- Schemas defined by using $ref are now correctly handled by Schema-Sync
- Interfaces generated by these $ref schemas are now prefixed with "SSGEN_" by default, but this is configurable using the config file (with the schemaTypePrefix key).
- Similarly, we can now add a custom prefix to all other generated types using the operationTypePrefix key